### PR TITLE
The get_hoststatus() and get_servicestatus() methods should raise a ValueError rather than return a ValueError object

### DIFF
--- a/pynag/Parsers/__init__.py
+++ b/pynag/Parsers/__init__.py
@@ -1473,7 +1473,7 @@ class status:
         for i in self.data['hoststatus']:
             if i.get('host_name') == host_name:
                 return i
-        return ValueError(host_name)
+        raise ValueError(host_name)
     def get_servicestatus(self, host_name, service_description):
         """ Returns a dictionary derived from status.dat for one particular service
         Returns:
@@ -1487,7 +1487,7 @@ class status:
             if i.get('host_name') == host_name:
                 if i.get('service_description') == service_description:
                     return i
-        return ValueError(host_name, service_description)
+        raise ValueError(host_name, service_description)
 
 
     def __setitem__(self, key, item):


### PR DESCRIPTION
As documented in the docstring of the get_hoststatus() and get_servicestatus() methods of the status class in the Parsers module, the methods should raise a ValueError object, but the current behaviour is to return a ValueError object. 

Either the docstring needs to be fixed or the code, this pull request is for the latter :)
