### PR TITLE
Services get stored in the wrong location

### DIFF
--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -1310,9 +1310,12 @@ class Service(ObjectDefinition):
     objects = ObjectFetcher('service')
 
     def get_shortname(self):
-        if not self.host_name and not self.service_description:
-            return None
-        return "%s/%s" % (self['host_name'], self['service_description'])
+        if self.host_name and self.service_description:
+            return "%s/%s" % (self['host_name'], self['service_description'])
+        if self.service_description:
+            return "%s" (self['service_description'], )
+
+        return None
 
     def _get_host_macro(self, macroname, host_name=None):
         if not host_name:


### PR DESCRIPTION
Edited get_shortname for class Service (fixed the None/servicedescription) problem

If you save a service without a host_name attached, it will be stored under /pynag_dir/services/None/service_description.

With this fix it will be stored under
/pynag_dir/services/service_description

Regards,
Christian
