### PR TITLE
perfdata on graphs

### DIFF
--- a/pynag/Plugins/__init__.py
+++ b/pynag/Plugins/__init__.py
@@ -238,7 +238,7 @@ class simple:
         """
         self.hr_range = ""
 
-        self._add_message_about_range_check(value)
+        self._add_message_from_range_check(value)
         self._check_messages_and_exit()
 
 


### PR DESCRIPTION
New style for writing perfdata "20;30..50;60..100" or the old style "20;30:50;60:100" breaks the rrd graphs and gives parsing errors. Plainly writing "20;30;60" works fine for graphs and it is possible through add_perfdata method. Only caveat is if that method is used, data it not checked. I added check_perfdata_as_metric method which checks the perfdata, and exits with the proper status code. 
