### PR TITLE
Unittest mock commands

### DIFF
--- a/tests/mocklivestatuscfg/nagios.cfg
+++ b/tests/mocklivestatuscfg/nagios.cfg
@@ -1,0 +1,1 @@
+broker_module=livestatus.o /tmp/livestatusmock


### PR DESCRIPTION
I moved the mocking to the external boundary of pynag. Writing to the command file is mocked at the command file.open() level and livestatus is mocked at the livestatus socket level.
