### PR TITLE
change hashbang to /usr/bin/env python

### DIFF
--- a/scripts/pynag
+++ b/scripts/pynag
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 # pynag - Python Nagios plug-in and configuration environment


### PR DESCRIPTION
The proper way? It at least fixes unit tests of the script when running in a virtualenv.
