### PR TITLE
fix negative filter bug in pynag.Model.Service.objects.filter

### DIFF
--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -471,6 +471,7 @@ class ObjectFetcher(object):
         kwargs = tmp
         for i in self.all:
             object_matches = True
+            negative_filter = False
             for k, v in kwargs.items():
                 if k.endswith('__exists'):
                     k = k[:-len('__exists')]
@@ -495,6 +496,7 @@ class ObjectFetcher(object):
                 elif k.endswith('__notcontains'):
                     k = k[:-13]
                     match_function = not_contains
+                    negative_filter = True
                 else:
                     match_function = str.__eq__
                 if object_matches == False:
@@ -510,8 +512,10 @@ class ObjectFetcher(object):
                     break
                 if not i.has_key(k):
                     if v is None: continue # if None was the search attribute
-                    object_matches = False
-                    break
+                    # Handle negated filter
+                    if not negative_filter:
+                        object_matches = False
+                        break
                 if not match_function(i[k], v):
                     object_matches = False
                     break

--- a/tests/test.py
+++ b/tests/test.py
@@ -433,13 +433,16 @@ class testUtils(unittest.TestCase):
         result = pynag.Utils.grep(hosts, **{'_function__has_field': 'Production'})
         self.assertEqual(2, len(result))
 
+        result = pynag.Utils.grep(hosts, **{'name__notcontains': 'A'})
+        self.assertEqual(1, len(result))
+
 
     def _compare_search_expressions(self, **expression):
         #print "Testing search expression %s" % expression
         all_services = pynag.Model.Service.objects.all
         result1 = pynag.Model.Service.objects.filter(**expression)
         result2 = pynag.Utils.grep(all_services, **expression)
-        self.assertEqual(result1, result2,msg="Search output from pynag.Utils.grep() does not match pynag.Model.Service.objects.filter() when using parameters %s" % expression)
+        self.assertEqual(result1, result2,msg="Search output from pynag.Utils.grep() does not match pynag.Model.Service.objects.filter() when using parameters %s\nFilter: %s\nGrep: %s" % (expression, result1, result2))
         return len(result1)
 
 def suite():


### PR DESCRIPTION
Test case was failing. This fixes it. Not sure if it's the intended behavior.

When Utils.grep() is called with __notcontains on an element that doesn't exist in the object it matches it and returns it in the result set. This patch makes Model.Service.objects.filter() do the same.

At least other test cases did not blow up :)
