### PR TITLE
Changing coveralls to run only after successful test run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - python setup.py install
 script:
   - coverage run --source=pynag tests/test.py
-after_script:
+after_success:
   - coveralls
 notifications:
   email: false


### PR DESCRIPTION
This should eliminate a lot of coveralls noise and reports of unknown coverage %.
