### PR TITLE
if Parsers.ParserError has filename and line number, print it

### DIFF
--- a/pynag/Parsers/__init__.py
+++ b/pynag/Parsers/__init__.py
@@ -1888,7 +1888,10 @@ class ParserError(Exception):
         self.line_start = item['meta'].get('line_start')
 
     def __str__(self):
-        return repr(self.message)
+        message = self.message
+        if self.filename and self.line_start:
+            message = '%s in %s, line %s' % (message, self.filename, self.line_start)
+        return repr(message)
 
 
 class LogFiles(object):


### PR DESCRIPTION
I had a few ParserErrors when I updated to 0.5.0 and modified my installation like this so I could find the bad config. I didn't find a way to inject the config file name and line number into the actual stack trace, which would have been cool.
