### PR TITLE
Drop support for native unittest test runs

### DIFF
--- a/tests/commandtest.py
+++ b/tests/commandtest.py
@@ -1,9 +1,6 @@
 import os
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest2 as unittest
 from mock import MagicMock, patch
 
 try:

--- a/tests/controltest.py
+++ b/tests/controltest.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest2 as unittest
 from mock import MagicMock
 
 import os

--- a/tests/plugintest.py
+++ b/tests/plugintest.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest2 as unittest
 import sys
 
 import pynag.Utils

--- a/tests/test.py
+++ b/tests/test.py
@@ -18,10 +18,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest2 as unittest
 import doctest
 import tempfile
 import shutil
@@ -43,19 +40,6 @@ import pynag.Plugins
 
 # Must run within test dir for relative paths to tests
 os.chdir(tests_dir)
-
-# skipIf workaround for python < 2.7
-try:
-    from unittest import skipIf
-except ImportError:
-    def skipIf(condition, message):
-        def decorator(f):
-            if condition:
-                return None
-            else:
-                return f
-        return decorator
-    unittest.skipIf = skipIf
 
 class testDatasetParsing(unittest.TestCase):
     """ Parse any dataset in the tests directory starting with "testdata" """

--- a/tests/test_defaultdict.py
+++ b/tests/test_defaultdict.py
@@ -3,10 +3,7 @@
 import os
 import copy
 import tempfile
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest2 as unittest
 
 from pynag.Utils import defaultdict
 

--- a/tests/utilstest.py
+++ b/tests/utilstest.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest2 as unittest
 from mock import MagicMock, patch
 
 import os
@@ -120,19 +117,8 @@ class testUtils(unittest.TestCase):
         expected_msg += '\* Command was:\n%s\n' % command
         expected_msg += '\* Output was:\n\n'
         expected_msg += 'Check if y/our path is correct: %s' % os.getenv('PATH')
-        # TODO change to unittest2 so assertRaisesRegexp works for python 2.6
-        """
         with self.assertRaisesRegexp(utils.PynagError, expected_msg):
             utils.runCommand(command, raise_error_on_fail=True)
-        """
-        import re
-        try:
-            utils.runCommand(command, raise_error_on_fail=True)
-        except PynagError, message:
-            match = re.match(expected_msg, message.args[0])
-            self.assertNotEqual(match, None)
-        else:
-            self.fail("PynagError not raised.")
 
     def test_gitrepo_init_empty(self):
         from getpass import getuser


### PR DESCRIPTION
Can simplify a lot of stuff since we want to be compatible back to python 2.4.
