### PR TITLE
Fix TypeError in PynagError's __init__ due to Python 2.4

### DIFF
--- a/pynag/Utils/__init__.py
+++ b/pynag/Utils/__init__.py
@@ -45,7 +45,10 @@ class PynagError(Exception):
         self.errorcode = errorcode
         self.message = message
         self.errorstring = errorstring
-        super(self.__class__, self).__init__(message, *args,**kwargs)
+        try:
+            super(self.__class__, self).__init__(message, *args,**kwargs)
+        except TypeError:  # Python 2.4 is fail
+            Exception.__init__(self, message, *args,**kwargs)
 
 
 def runCommand(command, raise_error_on_fail=False):


### PR DESCRIPTION
Python 2.4 Exception's are not new-style classes. Therefore, we cannot use
the super(Parent, self) syntax.

This fixes errors in test_invalid_threshold and test_invalid_range

```
  File "/home/nagios/pynag/pynag/Utils/__init__.py", line 48, in __init__
    super(self.__class__, self).__init__(message, *args,**kwargs)
TypeError: super() argument 1 must be type, not classobj
```

Note: I have not tested this with any other version of Python.
