### PR TITLE
Disable unit testing on rhel5 and older

### DIFF
--- a/pynag.spec
+++ b/pynag.spec
@@ -3,6 +3,18 @@
 %{!?python_version: %global python_version %(%{__python} -c "from distutils.sysconfig import get_python_version; print get_python_version()")}
 %endif
 
+# RHEL6 and newer has unittest2
+# All other distributions assume that we have access to unittest2
+%define unittest2 0
+%if 0%{?rhel} 
+%if 0%{?rhel} >= 6
+%define unittest2 1
+%endif
+%else
+%define unittest2 1
+%endif
+
+
 Summary: Python modules and utilities for Nagios plugins and configuration
 Name: pynag
 Version: 0.5.0
@@ -12,10 +24,12 @@ License: GPLv2
 Group: System Environment/Libraries
 BuildRequires: python-devel
 BuildRequires: python-setuptools
-BuildRequires: python-unittest2
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 Url: http://pynag.org/
 BuildArch: noarch
+%if 0%{?unittest2}
+BuildRequires: python-unittest2
+%endif
 
 %description
 Python modules and utilities for pragmatically handling Nagios configuration
@@ -35,12 +49,10 @@ are scripts which list services, do network discovery among other tasks.
 %setup -q
 
 %build
-%if 0%{?rhel} <= 5
-  # Unittests do not run currently on rhel 5 and older
-  %{__python} setup.py build
-%else
-  %{__python} setup.py build
-  %{__python} setup.py test
+%{__python} setup.py build
+
+%if 0%{?unittest2}
+%{__python} setup.py test
 %endif
 
 %install


### PR DESCRIPTION
Changes implemented in issue #72 and issue #83 break rpm builds on rhel5 or older. This pull request mitigates the issue of building on rhel5 by not running unittests during build. But we have not addressed if pynag unittests not functioning at all on python 2.4 is a good enough.
#### Running tests without unittest2 fails miserably

```
+ /usr/bin/python setup.py test
/usr/lib/python2.4/distutils/dist.py:236: UserWarning: Unknown distribution option: 'requires'
  warnings.warn(msg)
running test
Traceback (most recent call last):
  File "tests/build-test.py", line 24, in ?
    import test
  File "/root/pynag-0.6.1/tests/test.py", line 21, in ?
    import unittest2 as unittest
ImportError: No module named unittest2
```
#### pip installing unittest2 on rhel5 makes tests "a success" but none are run.. ;-)

```
# python setup.py test
/usr/lib/python2.4/distutils/dist.py:236: UserWarning: Unknown distribution option: 'requires'
  warnings.warn(msg)
running test

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
```
