### PR TITLE
MultiSite livestatus support

### DIFF
--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -250,6 +250,7 @@ class LogFiles(unittest.TestCase):
         self.assertEqual('./nagios/log/nagios.log', logfiles[0])
         self.assertEqual('./nagios/log/archives/archivelog1.log', logfiles[1])
 
+
 class Status(unittest.TestCase):
     @unittest.skipIf(os.getenv('TRAVIS', None) == 'true', "Running in Travis")
     def testStatus(self):
@@ -267,6 +268,32 @@ class Status(unittest.TestCase):
 
         # Try to get current version of nagios
         version = info['version']
+
+
+class MultiSite(Livestatus):
+    """ Tests for pynag.Parsers.MultiSite
+    """
+    def testAddBackend(self):
+        livestatus = pynag.Parsers.MultiSite()
+        backend1 = "local autodiscovered"
+        backend2 = "local autodiscovered2"
+
+        # Add a backend, and make sure we are getting hosts out of it
+        livestatus.add_backend(path=None, name=backend1)
+        hosts = livestatus.get_hosts()
+        self.assertTrue(len(hosts) > 0)
+
+        # Add the same backend under a new name, and check if number of hosts
+        # doubles
+        livestatus.add_backend(path=None, name=backend2)
+        hosts2 = livestatus.get_hosts()
+        self.assertEqual(len(hosts) * 2, len(hosts2))
+
+        # Get hosts from one specific backend
+        hosts_backend1 = livestatus.get_hosts(backend=backend1)
+        hosts_backend2 = livestatus.get_hosts(backend=backend2)
+
+        self.assertEqual(len(hosts), len(hosts_backend1))
 
 @unittest.skip("Not ready for production yet")
 class SshConfig(Config):


### PR DESCRIPTION
- New class: pynag.Parsers.MultiSite
- Behaves just like pynag.Parsers.mk_livestatus
- Should make MultiSite support in Adagios easier

Old way of writing livestatus code:

```
l = mk_livestatus(livestatus_socket_path="...")
l.get_hosts()
```

New way:

```
l = MultiSite()
l.add_backend(path="...", name="local connection"
l.add_backend(path="...", name="remote connection")
l.get_hosts()
l.get_hosts(backend="local connection")
```

Comments much appreciated.
