### PR TITLE
Fixed file_time bug

### DIFF
--- a/pynag/Utils/checkresult.py
+++ b/pynag/Utils/checkresult.py
@@ -41,7 +41,6 @@ class CheckResult(object):
 
         # Nagios is quite fussy about the filename, it must be
         # a 7 character name starting with 'c'
-        self.file_time = file_time
 
         self.fh, self.cmd_file = tempfile.mkstemp(prefix='c',
                                                   dir=nagios_result_dir)


### PR DESCRIPTION
The file_time=time.time() is not evaluated on multiple calls as the field is a default argument to the constructor.
