### PR TITLE
Attempting to fix a bug with trying to remove a scheduled downtime, in N...

### DIFF
--- a/scripts/pynag
+++ b/scripts/pynag
@@ -512,7 +512,7 @@ def _get_all_downtimes():
         result += s.data.get('servicedowntime', [])
         result += s.data.get('hostdowntime', [])
         for i in result:
-            i['id'] = i.get('comment_id', None)
+            i['id'] = i.get('downtime_id', None)
         return result
 def copy_object():
     parser.usage = ''' %prog copy <SET attr1=value1 [attr2=val2]> <WHERE ...> [--filename /path/to/file] '''


### PR DESCRIPTION
...agios you cannot use comment_id, because that only removes the comment from the service status page.  We found if you instead go to Downtime in the Nagios UI the downtime_id is the id we want to remove.  This PR is an attempt to fix this problem.  Curious for feedback.
