### PR TITLE
fix wrong variable name

### DIFF
--- a/pynag/Model/EventHandlers/__init__.py
+++ b/pynag/Model/EventHandlers/__init__.py
@@ -93,7 +93,7 @@ class FileLogger(BaseEventHandler):
 
     def debug(self, object_definition, message):
         """Used for any particular debug notifications"""
-        if self.debug:
+        if self._debug:
             message = "%s: %s" % (time.asctime(), message)
             self._append_to_file(message)
 


### PR DESCRIPTION
As set here: https://github.com/pynag/pynag/blob/master/pynag/Model/EventHandlers/__init__.py#L85
