### PR TITLE
pynag doesn't list services applied via a hostgroup when multiple levels...

### DIFF
--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -1552,7 +1552,7 @@ class Host(ObjectDefinition):
     def get_effective_hostgroups(self):
         """ Returns a list of all Hostgroup that belong to this Host """
         get_object = lambda x: Hostgroup.objects.get_by_shortname(x, cache_only=True)
-        list_of_shortnames = sorted(ObjectRelations.host_hostgroups[self.host_name])
+        list_of_shortnames = sorted(set(self._get_effective_attribute('hostgroups').split(',')))
         return map(get_object, list_of_shortnames)
 
     def get_effective_network_parents(self, recursive=False):


### PR DESCRIPTION
... of appends are used in the config

When a host is defined via multiple levels of inheritance containing hostgroups being appended at each level, pynag get_effective_hostgroups doesn't properly find all of the associated hostgroups with the leaf host.

The main issue is that in my situation, pynag does not return "mytestgroup" via get_effective_hostgroups, which means the "My Test Service" check_command can't be returned for the host "my-server".  I'm not sure what is wrong with ObjectRelations.host_hostgroups, but I noticed _get_effective_attribute exists as some kind of helper function to deal with this use case, yet it is never used anywhere.  A similar fix could be applied to contactgroups, servicegroups, etc.

This problem was seen in a large complex environment, but I haven't reproduced it yet in a simplified Nagios install, so stay tuned.  

Below is a representation of the config.
define hostgroup {
    hostgroup_name    mytestgroup
}
define hostgroup {
    hostgroup_name    my-web-node
}

define host {
    name                     my-server
    use                        linux-server
    hostgroups            +myproject,mytestgroup
    register                  0
}
define host {
    name                    my-server-development
    use                       my-server
}
define host {
    use                     my-server-development
    host_name         myhost
    hostgroups         +my-web-node
    address              127.0.0.1
}
define service{
    service_description My Test Service
    use                    local-service
    check_command dummy_command
    hostgroup_name mytestgroup
}
define command{
    command_name  dummy_command
    command_line     $USER1$/check_dummy 0 "My dummy check"
}
