### PR TITLE
Enh/Fix: livestatus expects a full query to be terminated by an empty li...

### DIFF
--- a/pynag/Parsers/__init__.py
+++ b/pynag/Parsers/__init__.py
@@ -2339,7 +2339,7 @@ class Livestatus(object):
 
         # When we reach here, we are done adding options to the query, so we convert to the string that will
         # be sent to the livestatus socket
-        query = '\n'.join(query) + '\n'
+        query = '\n'.join(query) + '\n\n'
         self.last_query = query
 
         #


### PR DESCRIPTION
...ne.

that would make the workaround used in the following PR  https://github.com/shinken-monitoring/mod-livestatus/pull/41 useless.
