### PR TITLE
Fix eventhandlers not called on copy object

### DIFF
--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -789,7 +789,8 @@ class ObjectDefinition(object):
                 del self._changes[k]
             self.is_new = False
             self._filename_has_changed = False
-            return config.item_add(self._original_attributes, self.get_filename())
+            self._event(level='write', message="Added new %s: %s" % (self.object_type, self.get_description()))
+            config.item_add(self._original_attributes, self.get_filename())
 
         # If we get here, we are making modifications to an object
         else:

--- a/pynag/Parsers/__init__.py
+++ b/pynag/Parsers/__init__.py
@@ -2712,7 +2712,7 @@ class Livestatus(object):
         return_code = header.split()[0]
         if not return_code.startswith('2'):
             error_message = header.strip()
-            raise LivestatusError("Error '%s' from livestatus: %s" % (return_code, error_message))
+            raise LivestatusError("Error '%s' from livestatus: %s" % (return_code, data))
         return data
 
     def query(self, query, *args, **kwargs):


### PR DESCRIPTION
In some cases where a host is copied to a new
file, the eventhandler 'save' was not called.

This patch fixes a bug in ObjectDefinition.save()
where the method was returned prematurely in case
we were writing to a new file.

Also added new unit test class for eventhandler calls.

Fixes opinkerfi/adagios#454
