### PR TITLE
Fix $HOSTDISPLAYNAME$ not being resolved correctly

### DIFF
--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -46,9 +46,10 @@ import time
 import getpass
 
 from pynag import Parsers
+from pynag.Model import macros
+
 import pynag.Control.Command
 import pynag.Utils
-from macros import _standard_macros
 import all_attributes
 
 
@@ -1103,9 +1104,6 @@ class ObjectDefinition(object):
             return self._get_service_macro(macroname)
         if macroname.startswith('$CONTACT') or macroname.startswith('$_CONTACT'):
             return self._get_contact_macro(macroname, contact_name=contact_name)
-        if macroname in _standard_macros:
-            attribute_name = _standard_macros[macroname]
-            return self.get(attribute_name, _UNRESOLVED_MACRO)
         return _UNRESOLVED_MACRO
 
     def set_macro(self, macroname, new_value):
@@ -1301,8 +1299,8 @@ class ObjectDefinition(object):
             return _UNRESOLVED_MACRO
         if macroname.startswith('$_SERVICE'):
             return self._get_custom_variable_macro(macroname)
-        elif macroname in _standard_macros:
-            attr = _standard_macros[macroname]
+        elif macroname in macros.STANDARD_SERVICE_MACROS:
+            attr = macros.STANDARD_SERVICE_MACROS[macroname]
             return self.get(attr, _UNRESOLVED_MACRO)
         elif macroname.startswith('$SERVICE'):
             name = macroname[8:-1].lower()
@@ -1311,13 +1309,15 @@ class ObjectDefinition(object):
 
     def _get_host_macro(self, macroname, host_name=None):
         if not pynag.Utils.is_macro(macroname):
-            return ''
+            return _UNRESOLVED_MACRO
         if macroname.startswith('$_HOST'):
             return self._get_custom_variable_macro(macroname)
         elif macroname == '$HOSTADDRESS$' and not self.address:
-            return self.get("host_name", _UNRESOLVED_MACRO)
-        elif macroname in _standard_macros:
-            attr = _standard_macros[macroname]
+            return self._get_host_macro('$HOSTNAME$')
+        elif macroname == '$HOSTDISPLAYNAME$' and not self.display_name:
+            return self._get_host_macro('$HOSTNAME$')
+        elif macroname in macros.STANDARD_HOST_MACROS:
+            attr = macros.STANDARD_HOST_MACROS[macroname]
             return self.get(attr, _UNRESOLVED_MACRO)
         elif macroname.startswith('$HOST'):
             name = macroname[5:-1].lower()
@@ -1326,7 +1326,7 @@ class ObjectDefinition(object):
 
     def _get_contact_macro(self, macroname, contact_name=None):
         if not pynag.Utils.is_macro(macroname):
-            return ''
+            return _UNRESOLVED_MACRO
         # If contact_name is not specified, get first effective contact and resolve macro for that contact
         if not contact_name:
             contacts = self.get_effective_contacts()
@@ -2049,8 +2049,8 @@ class Contact(ObjectDefinition):
     def _get_contact_macro(self, macroname, contact_name=None):
         if not pynag.Utils.is_macro(macroname):
             return _UNRESOLVED_MACRO
-        if macroname in _standard_macros:
-            attribute_name = _standard_macros.get(macroname, _UNRESOLVED_MACRO)
+        if macroname in macros.STANDARD_CONTACT_MACROS:
+            attribute_name = macros.STANDARD_CONTACT_MACROS[macroname]
         elif macroname.startswith('$_CONTACT'):
             return self._get_custom_variable_macro(macroname)
         elif macroname.startswith('$CONTACT'):

--- a/pynag/Model/macros.py
+++ b/pynag/Model/macros.py
@@ -26,9 +26,19 @@ i.e. macros['$HOSTADDR$'] should return 'address'
 # TODO: This hash map is incomplete, someone should type everything from the documentation to here:
 # See: http://nagios.sourceforge.net/docs/3_0/macrolist.html
 
-_standard_macros = {
+
+STANDARD_HOST_MACROS = {
     '$HOSTADDRESS$': 'address',
     '$HOSTNAME$': 'host_name',
+    '$HOSTDISPLAYNAME$': 'display_name',
+}
+
+
+STANDARD_SERVICE_MACROS = {
     '$SERVICEDESC$': 'service_description',
+}
+
+
+STANDARD_CONTACT_MACROS = {
     '$CONTACTEMAIL$': 'email',
 }

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -158,6 +158,17 @@ class TestMacroResolving(unittest.TestCase):
     def test_host_get_macro_address(self):
         self.assertEqual('macrohost2', self.macrohost2.get_macro('$HOSTADDRESS$'))
 
+    def test_host_get_macro_address_defaults_to_name(self):
+        self.macrohost2.address = 'my_addr'
+        self.assertEqual('my_addr', self.macrohost2.get_macro('$HOSTADDRESS$'))
+
+    def test_host_get_macro_display_name(self):
+        self.macrohost2.display_name = 'display_name'
+        self.assertEqual('display_name', self.macrohost2.get_macro('$HOSTDISPLAYNAME$'))
+
+    def test_host_get_macro_display_name_defaults_to_name(self):
+        self.assertEqual('macrohost2', self.macrohost2.get_macro('$HOSTDISPLAYNAME$'))
+
     def test_host_get_macro_custom(self):
         self.assertEqual('macrohost2', self.macrohost2.get_macro('$_HOST_macrohost2$'))
 


### PR DESCRIPTION
HOSTDISPLAYNAME should refer to self.display_name but was
defaulting to self.displayname

In addition if it is not defined it should refer to self.host_name

I also did a little bit of clean up of the standard macro look up. namely
split up _standard_macros in macros.py into STANDARD_SERVICE_MACROS, STANDARD_HOST_MACROS, etc

it still needs more work, but this change is only for the better.

contact macros remain fairly unusable and the list of standard macros in macros.py is fairly incomplete.
