### PR TITLE
Use "except Exception as var" everywhere

### DIFF
--- a/examples/Plugins/check_load.py
+++ b/examples/Plugins/check_load.py
@@ -16,7 +16,7 @@ helper.parse_arguments()
 # And if it fails, we exit immediately with UNKNOWN status
 try:
     content = open('/proc/loadavg').read()
-except Exception, e:
+except Exception as e:
     helper.exit(summary="Could not read /proc/loadavg", long_output=str(e), exit_code=unknown, perfdata='')
 
 

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -142,7 +142,7 @@ def execute_check_command():
         print ""
         if opts.quiet == False:
             print "# %s check exited with exit code %s" %(obj.object_type, exit_code)
-    except KeyError, e:
+    except KeyError as e:
         parser.error("Could not find host '%s'" % e)
 
 def search_objects(search_statements):
@@ -814,7 +814,7 @@ if __name__ == '__main__':
         debug = True
     try:
         parse_arguments()
-    except Exception, e:
+    except Exception as e:
         print "Error occured, use --debug to see full traceback:"
         print ""
         print "%s: %s" % (e.__class__.__name__, e)

--- a/tests/test_defaultdict.py
+++ b/tests/test_defaultdict.py
@@ -51,7 +51,7 @@ class TestDefaultDict(unittest.TestCase):
         self.assertEqual(d2.default_factory, None)
         try:
             d2[15]
-        except KeyError, err:
+        except KeyError as err:
             self.assertEqual(err.args, (15,))
         else:
             self.fail("d2[15] didn't raise KeyError")
@@ -155,7 +155,7 @@ class TestDefaultDict(unittest.TestCase):
         d1 = defaultdict()
         try:
             d1[(1,)]
-        except KeyError, err:
+        except KeyError as err:
             self.assertEqual(err.args[0], (1,))
         else:
             self.fail("expected KeyError")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -88,10 +88,10 @@ class PluginNoThreshold(unittest.TestCase):
         self.np.activate()
         try:
             self.np.check_range(value)
-        except SystemExit, e:
+        except SystemExit as e:
             self.assertEquals(type(e), type(SystemExit()))
             self.assertEquals(e.code, expected_exit)
-        except Exception, e:
+        except Exception as e:
             self.fail('unexpected exception: %s' % e)
         else:
             self.fail('SystemExit exception expected')
@@ -142,10 +142,10 @@ class PluginHelper(unittest.TestCase):
         try:
             self.my_plugin.check_all_metrics()
             self.my_plugin.exit()
-        except SystemExit, e:
+        except SystemExit as e:
             self.assertEquals(type(e), type(SystemExit()))
             self.assertEquals(e.code, expected_exit)
-        except Exception, e:
+        except Exception as e:
             self.fail('unexpected exception: %s' % e)
         else:
             self.fail('SystemExit exception expected')
@@ -321,7 +321,7 @@ class PluginHelper(unittest.TestCase):
             self.my_plugin.set_timeout(1)
             time.sleep(1)
             self.assertTrue(False, "Code should have timed out by now")
-        except SystemExit, e:
+        except SystemExit as e:
             self.assertEquals(type(e), type(SystemExit()))
             self.assertEquals(e.code, pynag.Plugins.unknown)
         self.assertTrue(True, "Timeout occured in plugin, just like expected.")
@@ -354,10 +354,10 @@ class Plugin(unittest.TestCase):
             self.np.add_message('OK', 'Some message')
             self.assertEquals(self.np.data['messages'][0], ['Some message'])
             self.np.check_range(value)
-        except SystemExit, e:
+        except SystemExit as e:
             self.assertEquals(type(e), type(SystemExit()))
             self.assertEquals(e.code, expected_exit)
-        except Exception, e:
+        except Exception as e:
             import traceback
             print(traceback.format_exc())
             self.fail('unexpected exception: %s' % e)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -340,7 +340,7 @@ class testUtils(unittest.TestCase):
         # code somewhere
         try:
             pynag.Utils.send_nsca(code=0, message="test", nscahost="localhost")
-        except OSError, e:
+        except OSError as e:
             # We don't care about the result if we have error because send_nsca
             # is not installed
             if e.errno != 2:


### PR DESCRIPTION
This patch removes the last cases where "except Exception, err:"
type syntax was used.
