### PR TITLE
Add printraw option to pynag list command

### DIFF
--- a/scripts/pynag
+++ b/scripts/pynag
@@ -705,9 +705,13 @@ def print_raw(objects):
         obj_attributes = []
         for attribute, value in obj.items():
             # Don't print pynag internal attributes
-            # or attributes with no value
-            if attribute in ["meta", "id"]:
+            # except the object type
+            if attribute == "id":
                 continue
+            if attribute == "meta":
+                obj_attributes.append("object_type={value}".format(value=urllib.quote(value['object_type'])))
+                continue
+            # or attributes with no value
             if not value:
                 continue
             obj_attributes.append("{attribute}={value}".format(attribute=attribute, value=urllib.quote(value)))

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -709,7 +709,7 @@ def get_nagios_attributes(obj):
         if attribute == "id":
             continue
         if attribute == "meta":
-            obj_attributes["object_type"] = value
+            obj_attributes["object_type"] = value['object_type']
             continue
         # or attributes with no value
         if not value:

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -23,6 +23,7 @@ import sys
 import traceback
 from optparse import OptionParser,OptionGroup
 import pprint
+import urllib
 import pynag.Model
 import pynag.Parsers
 import pynag.Utils
@@ -294,6 +295,8 @@ def list_objects():
     parser.usage = ''' %prog list [attribute1] [attribute2] [WHERE <...>] '''
     parser.add_option("--print", dest="print_definition", action='store_true',
                       default=False, help="Print actual definition instead of attributes")
+    parser.add_option("--printraw", dest="print_raw", action='store_true', default=False,
+                      help="Print all attributes of object in k=v format, values are urlquoted")
     (opts,args) = parser.parse_args(sys.argv[2:])
     pynag.Model.cfg_file = opts.cfg_file
     if opts.examples == True:
@@ -307,6 +310,8 @@ def list_objects():
     if opts.print_definition:
         for i in objects:
             print i
+    elif opts.print_raw:
+        print_raw(objects=objects)
     else:
         pretty_print(objects=objects,attributes=attributes)
 
@@ -690,6 +695,19 @@ def pretty_print(objects, attributes=None):
         pre = "-"*10
         post = "-"*(80-10-len(message))
         print pre + message + post
+
+def print_raw(objects):
+    for obj in objects:
+        obj_attributes = []
+        for attribute, value in obj.items():
+            # Don't print pynag internal attributes
+            # or attributes with no value
+            if attribute in ["meta", "id"]:
+                continue
+            if not value:
+                continue
+            obj_attributes.append("{attribute}={value}".format(attribute=attribute, value=urllib.quote(value)))
+        print parser.values.seperator.join(obj_attributes)
     
 def update_many(objects, **kwargs):
     """ Helper function to update many objects at once

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -697,6 +697,10 @@ def pretty_print(objects, attributes=None):
         print pre + message + post
 
 def print_raw(objects):
+    # If no column seperator was specified, use emptystring
+    if parser.values.seperator is None:
+        parser.values.seperator = ' '
+
     for obj in objects:
         obj_attributes = []
         for attribute, value in obj.items():

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -23,7 +23,6 @@ import sys
 import traceback
 from optparse import OptionParser,OptionGroup
 import pprint
-import urllib
 import json
 import pynag.Model
 import pynag.Parsers

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -24,6 +24,7 @@ import traceback
 from optparse import OptionParser,OptionGroup
 import pprint
 import urllib
+import json
 import pynag.Model
 import pynag.Parsers
 import pynag.Utils
@@ -295,8 +296,10 @@ def list_objects():
     parser.usage = ''' %prog list [attribute1] [attribute2] [WHERE <...>] '''
     parser.add_option("--print", dest="print_definition", action='store_true',
                       default=False, help="Print actual definition instead of attributes")
-    parser.add_option("--printraw", dest="print_raw", action='store_true', default=False,
-                      help="Print all attributes of object in k=v format, values are urlquoted")
+    parser.add_option("--printkv", dest="print_kv", action='store_true', default=False,
+                      help="Print all Nagios attributes of objects in k=v format, values are urlquoted")
+    parser.add_option("--printjson", dest="print_json", action='store_true', default=False,
+                      help="Print all Nagios attributes of objects in json format")
     (opts,args) = parser.parse_args(sys.argv[2:])
     pynag.Model.cfg_file = opts.cfg_file
     if opts.examples == True:
@@ -310,8 +313,10 @@ def list_objects():
     if opts.print_definition:
         for i in objects:
             print i
-    elif opts.print_raw:
-        print_raw(objects=objects)
+    elif opts.print_kv:
+        print_kv(objects=objects)
+    elif opts.print_json:
+        print_json(objects=objects)
     else:
         pretty_print(objects=objects,attributes=attributes)
 
@@ -696,26 +701,44 @@ def pretty_print(objects, attributes=None):
         post = "-"*(80-10-len(message))
         print pre + message + post
 
-def print_raw(objects):
+def get_nagios_attributes(obj):
+    obj_attributes = {}
+    for attribute, value in obj.items():
+        # Don't return pynag internal attributes
+        # except the object type
+        if attribute == "id":
+            continue
+        if attribute == "meta":
+            obj_attributes["object_type"] = value
+            continue
+        # or attributes with no value
+        if not value:
+            continue
+        obj_attributes[attribute] = value
+    return obj_attributes
+
+def print_kv(objects):
     # If no column seperator was specified, use emptystring
     if parser.values.seperator is None:
         parser.values.seperator = ' '
 
     for obj in objects:
-        obj_attributes = []
-        for attribute, value in obj.items():
-            # Don't print pynag internal attributes
-            # except the object type
-            if attribute == "id":
-                continue
-            if attribute == "meta":
-                obj_attributes.append("object_type={value}".format(value=urllib.quote(value['object_type'])))
-                continue
-            # or attributes with no value
-            if not value:
-                continue
-            obj_attributes.append("{attribute}={value}".format(attribute=attribute, value=urllib.quote(value)))
-        print parser.values.seperator.join(obj_attributes)
+        obj_attributes = get_nagios_attributes(obj)
+        attribute_kv = ["{attribute}={value}".format(attribute=attribute, value=urllib.quote(value))
+                for attribute, value in obj_attributes.iteritems()]
+        print parser.values.seperator.join(attribute_kv)
+
+def print_json(objects):
+    # If no column seperator was specified, use emptystring
+    if parser.values.seperator is None:
+        parser.values.seperator = ' '
+
+    all_objects = []
+    for obj in objects:
+        obj_attributes = get_nagios_attributes(obj)
+        all_objects.append(obj_attributes)
+
+    print json.dumps(all_objects)
     
 def update_many(objects, **kwargs):
     """ Helper function to update many objects at once

--- a/scripts/pynag
+++ b/scripts/pynag
@@ -296,10 +296,8 @@ def list_objects():
     parser.usage = ''' %prog list [attribute1] [attribute2] [WHERE <...>] '''
     parser.add_option("--print", dest="print_definition", action='store_true',
                       default=False, help="Print actual definition instead of attributes")
-    parser.add_option("--printkv", dest="print_kv", action='store_true', default=False,
-                      help="Print all Nagios attributes of objects in k=v format, values are urlquoted")
-    parser.add_option("--printjson", dest="print_json", action='store_true', default=False,
-                      help="Print all Nagios attributes of objects in json format")
+    parser.add_option("--json", dest="json", action='store_true', default=False,
+                      help="Print all attributes of objects in json format")
     (opts,args) = parser.parse_args(sys.argv[2:])
     pynag.Model.cfg_file = opts.cfg_file
     if opts.examples == True:
@@ -313,9 +311,7 @@ def list_objects():
     if opts.print_definition:
         for i in objects:
             print i
-    elif opts.print_kv:
-        print_kv(objects=objects)
-    elif opts.print_json:
+    elif opts.json:
         print_json(objects=objects)
     else:
         pretty_print(objects=objects,attributes=attributes)
@@ -701,32 +697,14 @@ def pretty_print(objects, attributes=None):
         post = "-"*(80-10-len(message))
         print pre + message + post
 
-def get_nagios_attributes(obj):
+def get_object_attributes(obj):
     obj_attributes = {}
     for attribute, value in obj.items():
-        # Don't return pynag internal attributes
-        # except the object type
-        if attribute == "id":
-            continue
-        if attribute == "meta":
-            obj_attributes["object_type"] = value['object_type']
-            continue
-        # or attributes with no value
-        if not value:
+        # Don't return attributes with no value
+        if value is None:
             continue
         obj_attributes[attribute] = value
     return obj_attributes
-
-def print_kv(objects):
-    # If no column seperator was specified, use emptystring
-    if parser.values.seperator is None:
-        parser.values.seperator = ' '
-
-    for obj in objects:
-        obj_attributes = get_nagios_attributes(obj)
-        attribute_kv = ["{attribute}={value}".format(attribute=attribute, value=urllib.quote(value))
-                for attribute, value in obj_attributes.iteritems()]
-        print parser.values.seperator.join(attribute_kv)
 
 def print_json(objects):
     # If no column seperator was specified, use emptystring
@@ -735,10 +713,10 @@ def print_json(objects):
 
     all_objects = []
     for obj in objects:
-        obj_attributes = get_nagios_attributes(obj)
+        obj_attributes = get_object_attributes(obj)
         all_objects.append(obj_attributes)
 
-    print json.dumps(all_objects)
+    print json.dumps(all_objects, indent=4)
     
 def update_many(objects, **kwargs):
     """ Helper function to update many objects at once

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -87,8 +87,8 @@ class testsFromCommandLine(unittest.TestCase):
         ok_commands = [
             "%s list" % pynag_script,
             "%s list where host_name=localhost and object_type=host" % pynag_script,
-            "%s list where host_name=localhost and object_type=host --printkv" % pynag_script,
-            "%s list where host_name=localhost and object_type=host --printjson" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --printkv --debug" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --printjson --debug" % pynag_script,
             "%s update where nonexistantfield=test set nonexistentfield=pynag_unit_testing" % pynag_script,
             "%s config --get cfg_dir" % pynag_script,
         ]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -87,6 +87,7 @@ class testsFromCommandLine(unittest.TestCase):
         ok_commands = [
             "%s list" % pynag_script,
             "%s list where host_name=localhost and object_type=host" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --printraw" % pynag_script,
             "%s update where nonexistantfield=test set nonexistentfield=pynag_unit_testing" % pynag_script,
             "%s config --get cfg_dir" % pynag_script,
         ]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -87,8 +87,7 @@ class testsFromCommandLine(unittest.TestCase):
         ok_commands = [
             "%s list" % pynag_script,
             "%s list where host_name=localhost and object_type=host" % pynag_script,
-            "%s list where host_name=localhost and object_type=host --printkv --debug" % pynag_script,
-            "%s list where host_name=localhost and object_type=host --printjson --debug" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --json --debug" % pynag_script,
             "%s update where nonexistantfield=test set nonexistentfield=pynag_unit_testing" % pynag_script,
             "%s config --get cfg_dir" % pynag_script,
         ]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -87,7 +87,8 @@ class testsFromCommandLine(unittest.TestCase):
         ok_commands = [
             "%s list" % pynag_script,
             "%s list where host_name=localhost and object_type=host" % pynag_script,
-            "%s list where host_name=localhost and object_type=host --printraw" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --printkv" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --printjson" % pynag_script,
             "%s update where nonexistantfield=test set nonexistentfield=pynag_unit_testing" % pynag_script,
             "%s config --get cfg_dir" % pynag_script,
         ]


### PR DESCRIPTION
This adds an option to the pynag list command. It outputs all set attributes of the filtered objects in a computer readable output. Before this change there was no way of retrieving attributes of objects without knowing the name of the attribute beforehand.

I'm open for discussion of what the option is called. The current `--print` option is a bit ambiguous IMO, should have been `--printdef` or even `--printraw`. But we won't change that now.