### PR TITLE
Add json option to pynag list command

### DIFF
--- a/scripts/pynag
+++ b/scripts/pynag
@@ -23,6 +23,7 @@ import sys
 import traceback
 from optparse import OptionParser,OptionGroup
 import pprint
+import json
 import pynag.Model
 import pynag.Parsers
 import pynag.Utils
@@ -294,6 +295,8 @@ def list_objects():
     parser.usage = ''' %prog list [attribute1] [attribute2] [WHERE <...>] '''
     parser.add_option("--print", dest="print_definition", action='store_true',
                       default=False, help="Print actual definition instead of attributes")
+    parser.add_option("--json", dest="json", action='store_true', default=False,
+                      help="Print all attributes of objects in json format")
     (opts,args) = parser.parse_args(sys.argv[2:])
     pynag.Model.cfg_file = opts.cfg_file
     if opts.examples == True:
@@ -307,6 +310,8 @@ def list_objects():
     if opts.print_definition:
         for i in objects:
             print i
+    elif opts.json:
+        print_json(objects=objects)
     else:
         pretty_print(objects=objects,attributes=attributes)
 
@@ -690,6 +695,27 @@ def pretty_print(objects, attributes=None):
         pre = "-"*10
         post = "-"*(80-10-len(message))
         print pre + message + post
+
+def get_object_attributes(obj):
+    obj_attributes = {}
+    for attribute, value in obj.items():
+        # Don't return attributes with no value
+        if value is None:
+            continue
+        obj_attributes[attribute] = value
+    return obj_attributes
+
+def print_json(objects):
+    # If no column seperator was specified, use emptystring
+    if parser.values.seperator is None:
+        parser.values.seperator = ' '
+
+    all_objects = []
+    for obj in objects:
+        obj_attributes = get_object_attributes(obj)
+        all_objects.append(obj_attributes)
+
+    print json.dumps(all_objects, indent=4)
     
 def update_many(objects, **kwargs):
     """ Helper function to update many objects at once

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -87,6 +87,7 @@ class testsFromCommandLine(unittest.TestCase):
         ok_commands = [
             "%s list" % pynag_script,
             "%s list where host_name=localhost and object_type=host" % pynag_script,
+            "%s list where host_name=localhost and object_type=host --json --debug" % pynag_script,
             "%s update where nonexistantfield=test set nonexistentfield=pynag_unit_testing" % pynag_script,
             "%s config --get cfg_dir" % pynag_script,
         ]


### PR DESCRIPTION
This adds an option to the pynag list command. It outputs all set attributes of the filtered objects in JSON format. Before this change there was no way of retrieving attributes of objects without knowing the name of the attribute beforehand.

Squash of #215 