### PR TITLE
Stop using pid file for needs_reload

### DIFF
--- a/pynag/Parsers/config_parser.py
+++ b/pynag/Parsers/config_parser.py
@@ -1597,8 +1597,6 @@ class Config(object):
         new_timestamps = self.get_timestamps()
         object_cache_file = self.get_cfg_value('object_cache_file')
 
-        if self._get_pid() is None:
-            return False
         if not object_cache_file:
             return True
         if not self.isfile(object_cache_file):
@@ -1727,7 +1725,7 @@ class Config(object):
         files = {}
         files[self.cfg_file] = None
         for k, v in self.maincfg_values:
-            if k in ('resource_file', 'lock_file', 'object_cache_file'):
+            if k in ('resource_file', 'object_cache_file'):
                 files[v] = None
         for i in self.get_cfg_files():
             files[i] = None


### PR DESCRIPTION
Systemd and possibly upstart run nagios in foreground mode. Nagios will not update lock_file (pid file) if run in foreground, therefor it is not possible to use for checking whether reloads are needed.

This has to be tested since other functionality might break and the age of the object.cache file might not be sufficient.