### PR TITLE
Set timestamps to integers for all commands.

### DIFF
--- a/pynag/Control/Command/__init__.py
+++ b/pynag/Control/Command/__init__.py
@@ -69,7 +69,7 @@ def find_command_file(cfg_file=None):
     return command_file
 
 
-def send_command(command_id, command_file=None, timestamp=0, *args):
+def send_command(command_id, command_file=None, timestamp=None, *args):
     """
     Send one specific command to the command pipe
 
@@ -83,8 +83,9 @@ def send_command(command_id, command_file=None, timestamp=0, *args):
         args: Command arguments.
 
     """
-    if not timestamp or timestamp == 0:
-        timestamp = int(time.time())
+    if not timestamp:
+        timestamp = time.time()
+    timestamp = int(timestamp)
     command_arguments = map(str, args)
     command_arguments = ";".join(command_arguments)
     command_string = "[%s] %s;%s" % (timestamp, command_id, command_arguments)


### PR DESCRIPTION
This patch ensures that when sending commands down the control
pipe all timestamps are converted to integer.

This fixes a problem where timestamps in form of string, or longs are
passed unmodifified to the api.