### PR TITLE
prevent doubling brackets around emails

### DIFF
--- a/pynag/Utils/git.py
+++ b/pynag/Utils/git.py
@@ -37,7 +37,7 @@ class GitRepo(object):
         if author_name is None:
             author_name = "Pynag User"
         if author_email is None:
-            author_email = "<%s@%s>" % (getuser(), node())
+            author_email = "%s@%s" % (getuser(), node())
         self.author_name = author_name
         self.author_email = author_email
 
@@ -68,7 +68,7 @@ class GitRepo(object):
             None
         """
         os.environ['GIT_AUTHOR_NAME'] = self.author_name
-        os.environ['GIT_AUTHOR_EMAIL'] = self.author_email.strip('<').strip('>')
+        os.environ['GIT_AUTHOR_EMAIL'] = self.author_email
 
     def _run_command(self, command):
         """ Run a specified command from the command line. Return stdout

--- a/pynag/Utils/git.py
+++ b/pynag/Utils/git.py
@@ -34,9 +34,9 @@ class GitRepo(object):
         self.directory = directory
 
         # Who made the change
-        if author_name is None:
+        if author_name is None or author_name.strip() == '':
             author_name = "Pynag User"
-        if author_email is None:
+        if author_email is None or author_email.strip() == '':
             author_email = "%s@%s" % (getuser(), node())
         self.author_name = author_name
         self.author_email = author_email

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,15 +164,17 @@ class testUtils(unittest.TestCase):
     def test_gitrepo_init_empty(self):
         from getpass import getuser
         from platform import node
-        repo = utils.GitRepo(
-            directory=self.tmp_dir,
-            auto_init=True,
-            author_name=None,
-            author_email=None
-        )
-        self.assertEquals(repo.author_name, 'Pynag User')
-        expected_email = '%s@%s' % (getuser(), node())
-        self.assertEquals(repo.author_email, expected_email)
+        emptyish = [None, '', ' ', '\n    ']
+        for x in emptyish:
+            repo = utils.GitRepo(
+                directory=self.tmp_dir,
+                auto_init=True,
+                author_name=x,
+                author_email=x
+            )
+            self.assertEquals(repo.author_name, 'Pynag User')
+            expected_email = '%s@%s' % (getuser(), node())
+            self.assertEquals(repo.author_email, expected_email)
 
     def test_gitrepo_init_with_author(self):
         tempfile.mkstemp(dir=self.tmp_dir)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,7 +171,7 @@ class testUtils(unittest.TestCase):
             author_email=None
         )
         self.assertEquals(repo.author_name, 'Pynag User')
-        expected_email = '<%s@%s>' % (getuser(), node())
+        expected_email = '%s@%s' % (getuser(), node())
         self.assertEquals(repo.author_email, expected_email)
 
     def test_gitrepo_init_with_author(self):


### PR DESCRIPTION
Creating a new `GitRepo` and using the automatically generated name and
email results in calls like `git commit --author='Pynag User <<user@host>>`

Changes `GitRepo` to assume `self.author_email` is un-bracketed, and add
brackets only when needed.