### PR TITLE
Config._get_list(): Remove whitespace from all elements.

### DIFF
--- a/pynag/Parsers/config_parser.py
+++ b/pynag/Parsers/config_parser.py
@@ -1055,6 +1055,9 @@ class Config(object):
         # Alphabetize
         return_list.sort()
 
+        # remove preceding and trailing whitespace from each element
+        return_list = map(lambda x : x.strip(), return_list)
+
         return return_list
 
     def delete_object(self, object_type, object_name, user_key=None):


### PR DESCRIPTION
Otherwise extended_parse() will stumble over a service definition
with a list like "hostgroup_name a,b, c,d",
since the hostgroup " c" is not defined.
Nagios however, ignores this whitespace.
