### PR TITLE
In hostgroup definition, support multi members

### DIFF
--- a/pynag/Parsers/config_parser.py
+++ b/pynag/Parsers/config_parser.py
@@ -530,6 +530,8 @@ class Config(object):
                 if (current['meta']['object_type'] == 'timeperiod') and key not in ('timeperiod_name', 'alias'):
                     key = line
                     value = ''
+                if (current['meta']['object_type'] == 'hostgroup') and key == 'members' and key in current:
+                    value = '%s,%s' % (current[key], value)
                 current[key] = value
                 current['meta']['defined_attributes'][key] = value
             # Something is wrong in the config


### PR DESCRIPTION
In hostgroup definition, more than one `members` allowed.

description below is equivalant of `members web01,web02,db01,db02` .

```
define hostgroup {
    hostgroup_name  SOMEHG
    alias           SOME Project
    members         web01
    members         web02
    members         db01
    members         db02
    }
```

Now pynag can handle last members, this PR enable these definition.