### PR TITLE
use_regexp_matching=0 does not work properly

### DIFF
--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -245,7 +245,7 @@ class ObjectRelations(object):
             always_use_regex = True
         else:
             always_use_regex = False
-        is_regex = lambda x: x is not None and (always_use_regex or '*' in x or '?' in x or '+' in x or '\.' in x)
+        is_regex = lambda x: x is not None and (always_use_regex or '*' in x or '?' in x or '\.' in x)
 
         # Strip None entries from full_list
         full_list = filter(lambda x: x is not None, full_list)

--- a/pynag/Model/__init__.py
+++ b/pynag/Model/__init__.py
@@ -241,11 +241,14 @@ class ObjectRelations(object):
         >>> hostgroup_hosts['hostgroup1'] == set(['localhost','remotehost'])
         True
         """
+        if config.get_cfg_value('use_regexp_matching') == "0":
+            return
+
         if config.get_cfg_value('use_true_regexp_matching') == "1":
             always_use_regex = True
         else:
             always_use_regex = False
-        is_regex = lambda x: x is not None and (always_use_regex or '*' in x or '?' in x or '\.' in x)
+        is_regex = lambda x: x is not None and (always_use_regex or '*' in x or '?' in x or '+' in x or '\.' in x)
 
         # Strip None entries from full_list
         full_list = filter(lambda x: x is not None, full_list)

--- a/pynag/Parsers/config_parser.py
+++ b/pynag/Parsers/config_parser.py
@@ -530,6 +530,8 @@ class Config(object):
                 if (current['meta']['object_type'] == 'timeperiod') and key not in ('timeperiod_name', 'alias'):
                     key = line
                     value = ''
+                if (current['meta']['object_type'] == 'hostgroup') and key == 'members' and key in current:
+                    value = '%s,%s' % (current[key], value)
                 current[key] = value
                 current['meta']['defined_attributes'][key] = value
             # Something is wrong in the config


### PR DESCRIPTION
When hostname include `+` , hostgroup missing.

- OK: hostname is `PROJECT-web-01`
- NonOK: hostname is `PROJECT-some+prefix-web-01`

I found that I can resolve above problem with this change.
( ... but I wonder why hostname want to treat as regex?)

----
append description at 2017/10/27

finally I found that my problem occured when `use_regexp_matching=0` and hostname contains `*?+.`