### PR TITLE
Fix import 'extra_opts' python3 issue

### DIFF
--- a/pynag/Plugins/__init__.py
+++ b/pynag/Plugins/__init__.py
@@ -31,7 +31,7 @@ import traceback
 import signal
 from optparse import OptionParser, OptionGroup
 from pynag.Utils import PerfData, reconsile_threshold
-from pynag.Parsers import extra_opts
+from pynag.Parsers import ExtraOptsParser
 import pynag.Utils
 import pynag.errors
 from pynag.Plugins import new_threshold_syntax
@@ -714,7 +714,7 @@ class PluginHelper(object):
 
         # Create an ExtraOptsParser instance and get all the values from that
         # config file
-        extra_opts = extra_opts.ExtraOptsParser(
+        extra_opts = ExtraOptsParser(
             section_name=section_name, config_file=config_file).get_values()
 
         for option in self.parser.option_list:


### PR DESCRIPTION
Fix local variable 'extra_opts' referenced before assignment error with python3

Fixing issue when using pynag@master with python3 - `extra_opts` name is reused in `parse_arguments` which calls `get_default_values` (which expect `extra_opts` to be the value from `from pynag.Parsers import extra_opts`)

```python
.tox/py3-test/lib/python3.7/site-packages/pynag/Plugins/__init__.py:558: in parse_arguments
    values = self.get_default_values(section_name, config_file)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = Unknown -, section_name = 'plugin', config_file = '/home/marek/Projects/linx-plugins/test/linxplugins/data/plugin.ini'

    def get_default_values(self, section_name=None, config_file=None):
        """ Returns an optionParser.Values instance of all defaults after parsing extra opts config file
    
        The Nagios extra-opts spec we use is the same as described here: http://nagiosplugins.org/extra-opts
    
        Arguments
    
        """
        # Get the program defaults
        values = self.parser.get_default_values()
    
        # Create an ExtraOptsParser instance and get all the values from that
        # config file
>       extra_opts = extra_opts.ExtraOptsParser(
            section_name=section_name, config_file=config_file).get_values()
E       UnboundLocalError: local variable 'extra_opts' referenced before assignment

```